### PR TITLE
Accumulation of a dead weight in Dijkstra

### DIFF
--- a/src/main/java/org/javanetworkanalyzer/alg/DijkstraForAccessibility.java
+++ b/src/main/java/org/javanetworkanalyzer/alg/DijkstraForAccessibility.java
@@ -35,6 +35,7 @@ import org.jgrapht.Graph;
  * destinations in an {@link AccessibilityAnalyzer}.
  *
  * @author Adam Gouge
+ * @author Olivier Bonin
  */
 // TODO: Enable **multiple** "closest" destinations within a given tolerance.
 public class DijkstraForAccessibility<E extends EdgeSPT> extends Dijkstra<VAccess, E> {
@@ -60,7 +61,8 @@ public class DijkstraForAccessibility<E extends EdgeSPT> extends Dijkstra<VAcces
      */
     @Override
     protected void shortestPathSoFarUpdate(VAccess startNode, VAccess u, VAccess v,
-                                           Double uvWeight, E e, PriorityQueue<VAccess> queue) {
+                                           Double uvWeight, 
+                                           Double uvDeadWeight, E e, PriorityQueue<VAccess> queue) {
         // If the distance from the start node to v (so the distance *from* v
         // *to* the destination represented by the start node in a reversed
         // graph) is less than the distance to any previously found closest
@@ -70,6 +72,6 @@ public class DijkstraForAccessibility<E extends EdgeSPT> extends Dijkstra<VAcces
             v.setDistanceToClosestDestination(distance);
             v.setClosestDestinationId(startNode.getID());
         }
-        super.shortestPathSoFarUpdate(startNode, u, v, uvWeight, e, queue);
+        super.shortestPathSoFarUpdate(startNode, u, v, uvWeight, uvDeadWeight, e, queue);
     }
 }

--- a/src/main/java/org/javanetworkanalyzer/alg/DijkstraForCentrality.java
+++ b/src/main/java/org/javanetworkanalyzer/alg/DijkstraForCentrality.java
@@ -37,6 +37,7 @@ import org.jgrapht.Graph;
  * betweenness and closeness in a {@link GraphAnalyzer}.
  *
  * @author Adam Gouge
+ * @author Olivier Bonin
  */
 public class DijkstraForCentrality<E extends EdgeSPT> extends Dijkstra<VWCent, E>
         implements CentralityAlg<VWCent, E, WeightedPathLengthData> {
@@ -116,10 +117,11 @@ public class DijkstraForCentrality<E extends EdgeSPT> extends Dijkstra<VWCent, E
     @Override
     protected void shortestPathSoFarUpdate(VWCent startNode, VWCent u, VWCent v,
                                            Double uvWeight,
+                                           Double uvDeadWeight,
                                            E e, PriorityQueue<VWCent> queue) {
         // Reset the number of shortest paths
         v.setSPCount(u.getSPCount());
-        super.shortestPathSoFarUpdate(startNode, u, v, uvWeight, e, queue);
+        super.shortestPathSoFarUpdate(startNode, u, v, uvWeight, uvDeadWeight, e, queue);
     }
 
     @Override

--- a/src/main/java/org/javanetworkanalyzer/alg/DistanceLength.java
+++ b/src/main/java/org/javanetworkanalyzer/alg/DistanceLength.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2015 obonin
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.javanetworkanalyzer.alg;
+
+/**
+ *
+ * @author obonin
+ */
+public class DistanceLength {
+    private double distance = 0;
+    private double length = 0;
+    
+    public DistanceLength(double d, double l) {
+        distance = d;
+        length = l;
+    }
+    
+    public double getDistance(){
+        return distance;
+    }
+    
+    public double getLength(){
+        return length;
+    }
+}

--- a/src/main/java/org/javanetworkanalyzer/alg/DistanceLength.java
+++ b/src/main/java/org/javanetworkanalyzer/alg/DistanceLength.java
@@ -17,13 +17,23 @@
 package org.javanetworkanalyzer.alg;
 
 /**
- *
+ * Helper class for the results of shortest paths computations on weighted
+ * graphs.
+ * By convention, the "distance" of a path is computed with the weight, and
+ * the "length" is computed with the dead weight (the dead weight is simply
+ * accumulated along the path but not used in the search). 
+ * 
+ * 
  * @author obonin
  */
 public class DistanceLength {
     private double distance = 0;
     private double length = 0;
     
+    /**
+     * @param d distance (sum of weights)
+     * @param l length (sum of dead weights)
+     */
     public DistanceLength(double d, double l) {
         distance = d;
         length = l;

--- a/src/main/java/org/javanetworkanalyzer/data/VBFS.java
+++ b/src/main/java/org/javanetworkanalyzer/data/VBFS.java
@@ -30,6 +30,7 @@ package org.javanetworkanalyzer.data;
  * @param <V> Vertex
  *
  * @author Adam Gouge
+ * @author Olivier Bonin
  */
 public class VBFS<V extends VBFS, E> extends VPredImpl<V, E> implements VDist<Integer> {
 
@@ -37,12 +38,16 @@ public class VBFS<V extends VBFS, E> extends VPredImpl<V, E> implements VDist<In
      * The default distance assigned to all nodes at the beginning of the BFS
      * algorithm.
      */
-    public static final int DEFAULT_DISTANCE = -1;
+    public static final int DEFAULT_DISTANCE = -1;    
+    public static final int DEFAULT_LENGTH = -1;
+
     /**
      * Number of steps on a shortest path from a certain source leading to this
      * node (BFS).
      */
     private int distance = DEFAULT_DISTANCE;
+    private int length = DEFAULT_DISTANCE;
+
 
     /**
      * Constructor: sets the id.
@@ -62,6 +67,16 @@ public class VBFS<V extends VBFS, E> extends VPredImpl<V, E> implements VDist<In
     public void setDistance(Integer newDistance) {
         distance = newDistance;
     }
+    
+    @Override
+    public Integer getLength() {
+        return length;
+    }
+
+    @Override
+    public void setLength(Integer newLength) {
+        length = newLength;
+    }
 
     /**
      * Clears the predecessor list and resets the distance to the default
@@ -73,6 +88,7 @@ public class VBFS<V extends VBFS, E> extends VPredImpl<V, E> implements VDist<In
         super.clear();
         // Reset the distance to the default distance.
         distance = DEFAULT_DISTANCE;
+        length = DEFAULT_LENGTH;
     }
 
     /**
@@ -84,5 +100,6 @@ public class VBFS<V extends VBFS, E> extends VPredImpl<V, E> implements VDist<In
         super.clear();
         // Set the distance to zero.
         distance = 0;
+        length = 0;
     }
 }

--- a/src/main/java/org/javanetworkanalyzer/data/VBFS.java
+++ b/src/main/java/org/javanetworkanalyzer/data/VBFS.java
@@ -35,8 +35,8 @@ package org.javanetworkanalyzer.data;
 public class VBFS<V extends VBFS, E> extends VPredImpl<V, E> implements VDist<Integer> {
 
     /**
-     * The default distance assigned to all nodes at the beginning of the BFS
-     * algorithm.
+     * The default distance and length assigned to all nodes at the beginning 
+     * of the BFS algorithm.
      */
     public static final int DEFAULT_DISTANCE = -1;    
     public static final int DEFAULT_LENGTH = -1;

--- a/src/main/java/org/javanetworkanalyzer/data/VDijkstra.java
+++ b/src/main/java/org/javanetworkanalyzer/data/VDijkstra.java
@@ -30,6 +30,7 @@ package org.javanetworkanalyzer.data;
  * @param <V> Vertex
  *
  * @author Adam Gouge
+ * @author Olivier Bonin
  */
 public class VDijkstra<V extends VDijkstra, E>
         extends VPredImpl<V, E>
@@ -40,11 +41,13 @@ public class VDijkstra<V extends VDijkstra, E>
      * Dijkstra algorithm.
      */
     public static final Double DEFAULT_DISTANCE = Double.POSITIVE_INFINITY;
+    public static final Double DEFAULT_LENGTH = Double.POSITIVE_INFINITY;
     /**
      * Length of a shortest path starting from a certain source leading to this
      * node (Dijkstra).
      */
     private double distance = DEFAULT_DISTANCE;
+    private double length = DEFAULT_LENGTH;
 
     /**
      * Constructor: Sets the id.
@@ -64,6 +67,16 @@ public class VDijkstra<V extends VDijkstra, E>
     public void setDistance(Double newDistance) {
         distance = newDistance;
     }
+    
+    @Override
+    public Double getLength() {
+        return length;
+    }
+
+    @Override
+    public void setLength(Double newLength) {
+        length = newLength;
+    }
 
     /**
      * Clears the predecessor list and resets the distance to the default
@@ -75,6 +88,7 @@ public class VDijkstra<V extends VDijkstra, E>
         super.clear();
         // Reset the distance to the default distance.
         distance = DEFAULT_DISTANCE;
+        length = DEFAULT_LENGTH;
     }
 
     /**
@@ -86,5 +100,6 @@ public class VDijkstra<V extends VDijkstra, E>
         super.clear();
         // Set the distance to zero.
         distance = 0.0;
+        length = 0.0;
     }
 }

--- a/src/main/java/org/javanetworkanalyzer/data/VDijkstra.java
+++ b/src/main/java/org/javanetworkanalyzer/data/VDijkstra.java
@@ -26,6 +26,12 @@ package org.javanetworkanalyzer.data;
 
 /**
  * Vertex to be used in the Dijkstra algorithm.
+ * 
+ * Each vertex has 
+ * - a "distance" (sum of the weights of a shortest path starting from a certain
+ * source leading to this node, used by the Dijkstra algorithm)
+ * - a "length" (sum of the dead weights of a shortest path starting from a 
+ * certain source leading to this node, unused by the Dijkstra algorithm).
  *
  * @param <V> Vertex
  *
@@ -37,8 +43,8 @@ public class VDijkstra<V extends VDijkstra, E>
         implements VDist<Double> {
 
     /**
-     * The default distance assigned to all nodes at the beginning of the
-     * Dijkstra algorithm.
+     * The default distance and length assigned to all nodes at the beginning 
+     * of the Dijkstra algorithm.
      */
     public static final Double DEFAULT_DISTANCE = Double.POSITIVE_INFINITY;
     public static final Double DEFAULT_LENGTH = Double.POSITIVE_INFINITY;

--- a/src/main/java/org/javanetworkanalyzer/data/VDist.java
+++ b/src/main/java/org/javanetworkanalyzer/data/VDist.java
@@ -30,6 +30,7 @@ package org.javanetworkanalyzer.data;
  * @param <D> Distance type (usually Integer or Double)
  *
  * @author Adam Gouge
+ * @author Olivier Bonin
  */
 public interface VDist<D extends Number> {
 
@@ -46,6 +47,10 @@ public interface VDist<D extends Number> {
      * @param newDistance Length of a shortest path to this node.
      */
     void setDistance(D newDistance);
+    
+    D getLength();
+    
+    void setLength(D newLength);
 
     /**
      * Resets this node's distance to the default distance value.

--- a/src/main/java/org/javanetworkanalyzer/graphcreators/WeightedGraphCreator.java
+++ b/src/main/java/org/javanetworkanalyzer/graphcreators/WeightedGraphCreator.java
@@ -48,21 +48,33 @@ public class WeightedGraphCreator<V extends VId, E extends Edge>
      * Weight index.
      */
     protected static int weightFieldIndex = -1;
+    
+    /**
+     * Dead weight column name.
+     */
+    private final String deadWeightField;
+    /**
+     * Dead weight index.
+     */
+    protected static int deadWeightFieldIndex = -1;
 
     /**
      * Initializes a new {@link WeightedGraphCreator}.
      *
      * @param csvFile     CSV file containing the edge information.
      * @param weightField The weight column name.
+     * @param deadWeightField The dead weight column name.
      * @param orientation The desired graph orientation.
      */
     public WeightedGraphCreator(String csvFile,
                                 int orientation,
                                 Class<? extends V> vertexClass,
                                 Class<? extends E> edgeClass,
-                                String weightField) {
+                                String weightField,
+                                String deadWeightField) {
         super(csvFile, orientation, vertexClass, edgeClass);
         this.weightField = weightField;
+        this.deadWeightField = deadWeightField;
     }
 
     @Override
@@ -92,6 +104,9 @@ public class WeightedGraphCreator<V extends VId, E extends Edge>
             } else if (row[i].replace(DOUBLE_QUOTES, EMPTY_STRING)
                     .equals(weightField)) {
                 weightFieldIndex = i;
+            } else if (row[i].replace(DOUBLE_QUOTES, EMPTY_STRING)
+                    .equals(deadWeightField)) {
+                deadWeightFieldIndex = i;
             }
         }
     }
@@ -126,6 +141,9 @@ public class WeightedGraphCreator<V extends VId, E extends Edge>
         double weight = Double.parseDouble(
                 deleteDoubleQuotes(row[weightFieldIndex]));
         edge.setWeight(weight);
+        double deadWeight = Double.parseDouble(
+                deleteDoubleQuotes(row[deadWeightFieldIndex]));
+        edge.setDeadWeight(deadWeight);
         return edge;
     }
 }

--- a/src/main/java/org/javanetworkanalyzer/model/Edge.java
+++ b/src/main/java/org/javanetworkanalyzer/model/Edge.java
@@ -31,11 +31,13 @@ import org.jgrapht.graph.DefaultWeightedEdge;
  * Weighted edge for use in {@link TraversalGraph}.
  *
  * @author Adam Gouge
+ * @author Olivier Bonin
  */
 public class Edge<E extends Edge> extends DefaultWeightedEdge
         implements EdgeSPT<E>, EdgeID {
 
     private double weight = WeightedGraph.DEFAULT_EDGE_WEIGHT;
+    private double deadWeight = WeightedGraph.DEFAULT_EDGE_WEIGHT;
     private E baseGraphEdge;
     private int id;
     private boolean setID = false;
@@ -51,6 +53,15 @@ public class Edge<E extends Edge> extends DefaultWeightedEdge
     @Override
     protected double getWeight() {
         return weight;
+    }
+    
+    public Edge setDeadWeight(double newWeight) {
+        deadWeight = newWeight;
+        return this;
+    }
+
+    public double getDeadWeight() {
+        return deadWeight;
     }
 
     @Override

--- a/src/main/java/org/javanetworkanalyzer/model/Edge.java
+++ b/src/main/java/org/javanetworkanalyzer/model/Edge.java
@@ -29,6 +29,10 @@ import org.jgrapht.graph.DefaultWeightedEdge;
 
 /**
  * Weighted edge for use in {@link TraversalGraph}.
+ * 
+ * Each edge has a weight, used for shortest paths computation (typically
+ * travel time) and a deadWeight, accumulated but not used (typically edge
+ * length).
  *
  * @author Adam Gouge
  * @author Olivier Bonin
@@ -55,6 +59,9 @@ public class Edge<E extends Edge> extends DefaultWeightedEdge
         return weight;
     }
     
+    /**
+     * Sets the deadWeight of this edge
+     */
     public Edge setDeadWeight(double newWeight) {
         deadWeight = newWeight;
         return this;
@@ -64,6 +71,12 @@ public class Edge<E extends Edge> extends DefaultWeightedEdge
         return deadWeight;
     }
 
+    public Edge setWeightAndDeadWeight(double newWeight) {
+        weight = newWeight;
+        deadWeight = newWeight;
+        return this;
+    }
+    
     @Override
     public E getBaseGraphEdge() {
         return baseGraphEdge;

--- a/src/main/java/org/javanetworkanalyzer/model/EdgeCent.java
+++ b/src/main/java/org/javanetworkanalyzer/model/EdgeCent.java
@@ -41,4 +41,11 @@ public class EdgeCent extends Edge<EdgeCent> {
         super.setWeight(newWeight);
         return this;
     }
+    
+    @Override
+    public EdgeCent setWeightAndDeadWeight(double newWeight) {
+        super.setWeight(newWeight);
+        super.setDeadWeight(newWeight);
+        return this;
+    }
 }

--- a/src/main/java/org/javanetworkanalyzer/model/EdgeSPT.java
+++ b/src/main/java/org/javanetworkanalyzer/model/EdgeSPT.java
@@ -13,5 +13,9 @@ public interface EdgeSPT<E extends EdgeSPT> {
 
     void setBaseGraphEdge(E e);
     
+    /**
+     * The dead weight is specified here, as it is an extension of the jGraphT
+     * data structure.
+     */
     double getDeadWeight();
 }

--- a/src/main/java/org/javanetworkanalyzer/model/EdgeSPT.java
+++ b/src/main/java/org/javanetworkanalyzer/model/EdgeSPT.java
@@ -5,10 +5,13 @@ package org.javanetworkanalyzer.model;
  * {@link org.javanetworkanalyzer.alg.TraversalAlg}.
  *
  * @author Adam Gouge
+ * @author Olivier Bonin
  */
 public interface EdgeSPT<E extends EdgeSPT> {
 
     E getBaseGraphEdge();
 
     void setBaseGraphEdge(E e);
+    
+    double getDeadWeight();
 }

--- a/src/test/java/org/javanetworkanalyzer/alg/DijkstraCormenUndirectedStarToStarTest.java
+++ b/src/test/java/org/javanetworkanalyzer/alg/DijkstraCormenUndirectedStarToStarTest.java
@@ -41,6 +41,7 @@ import static org.junit.Assert.assertEquals;
  * between pairs of nodes are calculated.
  *
  * @author Adam Gouge
+ * @author Olivier Bonin
  */
 //                   1
 //           >2 ------------>3
@@ -69,7 +70,7 @@ public class DijkstraCormenUndirectedStarToStarTest {
 
             for (VWCent source : g.vertexSet()) {
                 for (VWCent target : g.vertexSet()) {
-                    double distance = dijkstra.oneToOne(source, target);
+                    double distance = dijkstra.oneToOne(source, target).getDistance();
                     assertEquals(expectedDistances.get(source).get(target),
                                  distance, TOLERANCE);
                 }
@@ -90,11 +91,11 @@ public class DijkstraCormenUndirectedStarToStarTest {
             for (VWCent source : g.vertexSet()) {
                 // Note: This is a oneToAll. It should be equivalent to
                 // dijkstra.calculate(source);
-                Map<VWCent, Double> distances =
+                Map<VWCent, DistanceLength> distances =
                         dijkstra.oneToMany(source, g.vertexSet());
-                for (Entry<VWCent, Double> e : distances.entrySet()) {
+                for (Entry<VWCent, DistanceLength> e : distances.entrySet()) {
                     VWCent target = e.getKey();
-                    Double distance = e.getValue();
+                    Double distance = e.getValue().getDistance();
                     assertEquals(expectedDistances.get(source).get(target),
                                  distance, TOLERANCE);
                 }
@@ -114,11 +115,11 @@ public class DijkstraCormenUndirectedStarToStarTest {
 
             for (VWCent target : g.vertexSet()) {
                 // Note: This is an allToOne.
-                Map<VWCent, Double> distances =
+                Map<VWCent, DistanceLength> distances =
                         dijkstra.manyToOne(g.vertexSet(), target);
-                for (Entry<VWCent, Double> e : distances.entrySet()) {
+                for (Entry<VWCent, DistanceLength> e : distances.entrySet()) {
                     VWCent source = e.getKey();
-                    Double distance = e.getValue();
+                    Double distance = e.getValue().getDistance();
                     assertEquals(expectedDistances.get(source).get(target),
                                  distance, TOLERANCE);
                 }
@@ -137,14 +138,14 @@ public class DijkstraCormenUndirectedStarToStarTest {
             Dijkstra<VWCent, Edge> dijkstra = new Dijkstra<VWCent, Edge>(g);
 
             // Note: This is an allToAll.
-            Map<VWCent, Map<VWCent, Double>> distances =
+            Map<VWCent, Map<VWCent, DistanceLength>> distances =
                     dijkstra.manyToMany(g.vertexSet(), g.vertexSet());
-            for (Entry<VWCent, Map<VWCent, Double>> e : distances.entrySet()) {
+            for (Entry<VWCent, Map<VWCent, DistanceLength>> e : distances.entrySet()) {
                 VWCent source = e.getKey();
-                Map<VWCent, Double> distancesKeyedByTarget = e.getValue();
-                for (Entry<VWCent, Double> f : distancesKeyedByTarget.entrySet()) {
+                Map<VWCent, DistanceLength> distancesKeyedByTarget = e.getValue();
+                for (Entry<VWCent, DistanceLength> f : distancesKeyedByTarget.entrySet()) {
                     VWCent target = f.getKey();
-                    double distance = f.getValue();
+                    double distance = f.getValue().getDistance();
                     assertEquals(expectedDistances.get(source).get(target),
                                  distance, TOLERANCE);
                 }

--- a/src/test/java/org/javanetworkanalyzer/analyzers/AccessibilityAnalyzerTest.java
+++ b/src/test/java/org/javanetworkanalyzer/analyzers/AccessibilityAnalyzerTest.java
@@ -37,6 +37,7 @@ import static org.junit.Assert.*;
  * possible configurations.
  *
  * @author Adam Gouge
+ * @author Olivier Bonin
  */
 public class AccessibilityAnalyzerTest extends CormenGraphPrep {
 
@@ -46,6 +47,7 @@ public class AccessibilityAnalyzerTest extends CormenGraphPrep {
     public void testD() throws Exception {
         DirectedG<VAccess, EdgeCent> g = directed();
         test(g);
+        System.out.println(g.getVertex(1));
         assertEquals(4, g.getVertex(1).getClosestDestinationId());
         assertEquals(1.0, g.getVertex(1).getDistanceToClosestDestination(),
                      TOLERANCE);

--- a/src/test/java/org/javanetworkanalyzer/analyzers/GraphAnalyzerTest.java
+++ b/src/test/java/org/javanetworkanalyzer/analyzers/GraphAnalyzerTest.java
@@ -43,6 +43,7 @@ import org.slf4j.LoggerFactory;
  * Tests weighted and unweighted graph analysis.
  *
  * @author Adam Gouge
+ * @author Olivier Bonin
  */
 public abstract class GraphAnalyzerTest
         extends CentralityTest {
@@ -268,7 +269,8 @@ public abstract class GraphAnalyzerTest
                                             orientation,
                                             VWCent.class,
                                             EdgeCent.class,
-                                            getWeightColumnName()).loadGraph();
+                                            getWeightColumnName(),
+                                            getDeadWeightColumnName()).loadGraph();
         } catch (Exception ex) {
         }
         return null;
@@ -355,6 +357,13 @@ public abstract class GraphAnalyzerTest
      * @return The weight column name.
      */
     protected abstract String getWeightColumnName();
+    
+    /**
+     * Returns the dead weight column name.
+     *
+     * @return The weight column name.
+     */
+    protected abstract String getDeadWeightColumnName();
 
     /**
      * Returns the number of nodes in this graph.

--- a/src/test/java/org/javanetworkanalyzer/analyzers/ManuallyCreatedGraphAnalyzerTest.java
+++ b/src/test/java/org/javanetworkanalyzer/analyzers/ManuallyCreatedGraphAnalyzerTest.java
@@ -35,6 +35,7 @@ import static org.javanetworkanalyzer.graphcreators.GraphCreator.UNDIRECTED;
  * Test helper for manually-entered graphs.
  *
  * @author Adam Gouge
+ * @author Olivier Bonin
  */
 public abstract class ManuallyCreatedGraphAnalyzerTest extends GraphAnalyzerTest {
 
@@ -68,7 +69,8 @@ public abstract class ManuallyCreatedGraphAnalyzerTest extends GraphAnalyzerTest
      */
     protected abstract void addWeightedEdges(
             WeightedKeyedGraph<? extends VCent, EdgeCent> graph);
-
+    
+ 
     /**
      * Loads an unweighted graph with the given orientation.
      *
@@ -165,6 +167,7 @@ public abstract class ManuallyCreatedGraphAnalyzerTest extends GraphAnalyzerTest
         WeightedKeyedGraph<? extends VCent, EdgeCent> graph = null;
         try {
             graph = initializeWeightedGraph(getWeightColumnName(),
+                                            getDeadWeightColumnName(),
                                             GraphCreator.DIRECTED);
             addVertices(graph);
             addWeightedEdges(graph);
@@ -193,6 +196,7 @@ public abstract class ManuallyCreatedGraphAnalyzerTest extends GraphAnalyzerTest
         WeightedKeyedGraph<? extends VCent, EdgeCent> graph = null;
         try {
             graph = initializeWeightedGraph(getWeightColumnName(),
+                                            getDeadWeightColumnName(),
                                             GraphCreator.UNDIRECTED);
             addVertices(graph);
             addWeightedEdges((WeightedKeyedGraph) graph);
@@ -231,6 +235,7 @@ public abstract class ManuallyCreatedGraphAnalyzerTest extends GraphAnalyzerTest
      */
     private WeightedKeyedGraph<? extends VCent, EdgeCent> initializeWeightedGraph(
             String weightColumnName,
+            String deadWeightColumnName,
             int orientation) throws NoSuchMethodException {
         if (orientation != UNDIRECTED) {
             return new DirectedWeightedPseudoG<VWCent, EdgeCent>(
@@ -254,6 +259,14 @@ public abstract class ManuallyCreatedGraphAnalyzerTest extends GraphAnalyzerTest
      */
     @Override
     protected String getWeightColumnName() {
+        return "";
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected String getDeadWeightColumnName() {
         return "";
     }
 }

--- a/src/test/java/org/javanetworkanalyzer/analyzers/examples/ExampleGraphTest.java
+++ b/src/test/java/org/javanetworkanalyzer/analyzers/examples/ExampleGraphTest.java
@@ -73,12 +73,12 @@ public class ExampleGraphTest extends ManuallyCreatedGraphAnalyzerTest {
     @Override
     protected void addWeightedEdges(
             WeightedKeyedGraph<? extends VCent, EdgeCent> graph) {
-        graph.addEdge(1, 2).setWeight(1.2);
-        graph.addEdge(1, 3).setWeight(0.8);
-        graph.addEdge(1, 5).setWeight(1.0);
-        graph.addEdge(5, 2).setWeight(0.3);
-        graph.addEdge(2, 4).setWeight(0.9);
-        graph.addEdge(3, 4).setWeight(1.3);
+        graph.addEdge(1, 2).setWeightAndDeadWeight(1.2);
+        graph.addEdge(1, 3).setWeightAndDeadWeight(0.8);
+        graph.addEdge(1, 5).setWeightAndDeadWeight(1.0);
+        graph.addEdge(5, 2).setWeightAndDeadWeight(0.3);
+        graph.addEdge(2, 4).setWeightAndDeadWeight(0.9);
+        graph.addEdge(3, 4).setWeightAndDeadWeight(1.3);
     }
 
     @Test

--- a/src/test/java/org/javanetworkanalyzer/analyzers/examples/Graph2DAnalyzerTest.java
+++ b/src/test/java/org/javanetworkanalyzer/analyzers/examples/Graph2DAnalyzerTest.java
@@ -45,6 +45,7 @@ public class Graph2DAnalyzerTest extends GraphAnalyzerTest {
     private final static String GRAPH2D = "2D Graph";
     private static final String FILENAME = "./files/graph2D.edges.csv";
     private static final String LENGTH = "length";
+    private static final String DISTANCE = "speed";
     private static final boolean PRINT_RESULTS = false;
     private static final boolean CHECK_RESULTS = true;
     private static final int NUMBER_OF_NODES = 6;
@@ -155,6 +156,11 @@ public class Graph2DAnalyzerTest extends GraphAnalyzerTest {
         return LENGTH;
     }
 
+    @Override
+    protected String getDeadWeightColumnName() {
+        return DISTANCE;
+    }
+    
     @Override
     public String getName() {
         return GRAPH2D;

--- a/src/test/java/org/javanetworkanalyzer/graphcreators/CormenGraphPrep.java
+++ b/src/test/java/org/javanetworkanalyzer/graphcreators/CormenGraphPrep.java
@@ -33,6 +33,7 @@ import org.javanetworkanalyzer.model.EdgeCent;
  * Prepares the Cormen graph.
  *
  * @author Adam Gouge
+ * @author Olivier Bonin
  */
 //                   1
 //           >2 ------------>3

--- a/src/test/java/org/javanetworkanalyzer/graphcreators/Graph2DGraphCreatorTest.java
+++ b/src/test/java/org/javanetworkanalyzer/graphcreators/Graph2DGraphCreatorTest.java
@@ -40,11 +40,13 @@ import org.slf4j.LoggerFactory;
  * unweighted; directed, reversed or undirected).
  *
  * @author Adam Gouge
+ * @author Olivier Bonin
  */
 public class Graph2DGraphCreatorTest {
 
     private static final String FILENAME = "./files/graph2D.edges.csv";
     private static final String WEIGHT = "length";
+    private static final String DEADWEIGHT = "speed";
     private static final Logger LOGGER =
             LoggerFactory.getLogger(Graph2DGraphCreatorTest.class);
 
@@ -113,7 +115,8 @@ public class Graph2DGraphCreatorTest {
                     orientation,
                     VWCent.class,
                     Edge.class,
-                    WEIGHT).loadGraph();
+                    WEIGHT,
+                    DEADWEIGHT).loadGraph();
         } else {
             graph = new GraphCreator<VUCent, Edge>(
                     FILENAME,


### PR DESCRIPTION
A secondary weight ("dead" weight) can be accumulated along shortest paths. Thus if the weight is the travel time of the path, the dead weight can be the distance.
